### PR TITLE
Fixed cmake with 5.6 mysql_config/-fno-rtti

### DIFF
--- a/FindMySQL.cmake
+++ b/FindMySQL.cmake
@@ -749,6 +749,8 @@ if(NOT WIN32)
     if(NOT MYSQL_CXXFLAGS)
       if(MYSQL_CXX_LINKAGE OR MYSQL_VERSION_ID GREATER 50603)
         _mysql_conf(MYSQL_CXXFLAGS "--cxxflags")
+        # remove no-rtti if set
+        string(REPLACE " -fno-rtti" "" MYSQL_CXXFLAGS  "${MYSQL_CXXFLAGS}")
         set(MYSQL_CXX_LINKAGE 1)
       else()
         set(MYSQL_CXXFLAGS "${MYSQL_CFLAGS}")


### PR DESCRIPTION
When building on Ubuntu 15.04 using the standard system mysql_config (version
5.6.x), the resulting make was failing due to the inherited Ubuntu 15.04 mysql
compile time parameter -fno-rtti

This caused a failure in the source when typeid() is used as runtime type
information is required for typeid() to function.

Resolves: Bug #80536