### PR TITLE
Fixes compilation failure with pre-5.7 C API

### DIFF
--- a/driver/mysql_resultbind.cpp
+++ b/driver/mysql_resultbind.cpp
@@ -86,8 +86,10 @@ static struct st_buffer_size_type
     case MYSQL_TYPE_BLOB:
     case MYSQL_TYPE_STRING:
     case MYSQL_TYPE_VAR_STRING:
+#ifdef MYSQL_TYPE_JSON
     case MYSQL_TYPE_JSON:
       return st_buffer_size_type(new char[field->max_length + 1], field->max_length + 1, field->type);
+#endif
 
     case MYSQL_TYPE_DECIMAL:
     case MYSQL_TYPE_NEWDECIMAL:

--- a/driver/mysql_util.cpp
+++ b/driver/mysql_util.cpp
@@ -431,8 +431,10 @@ mysql_type_to_datatype(const MYSQL_FIELD * const field)
       return sql::DataType::SET;
     case MYSQL_TYPE_GEOMETRY:
       return sql::DataType::GEOMETRY;
+#ifdef MYSQL_TYPE_JSON
     case MYSQL_TYPE_JSON:
       return sql::DataType::JSON;
+#endif
     default:
       return sql::DataType::UNKNOWN;
   }
@@ -498,8 +500,10 @@ mysql_string_type_to_datatype(const sql::SQLString & name)
     return sql::DataType::SET;
   } else if (!name.compare("geometry")) {
     return sql::DataType::GEOMETRY;
+#ifdef MYSQL_TYPE_JSON
   } else if (!name.compare("json")) {
     return sql::DataType::JSON;
+#endif
   } else {
     return sql::DataType::UNKNOWN;
   }
@@ -645,8 +649,10 @@ mysql_type_to_string(const MYSQL_FIELD * const field, boost::shared_ptr< sql::my
       return "SET";
     case MYSQL_TYPE_GEOMETRY:
       return "GEOMETRY";
+#ifdef MYSQL_TYPE_JSON
     case MYSQL_TYPE_JSON:
       return "JSON";
+#endif
     default:
       return "UNKNOWN";
   }


### PR DESCRIPTION
When compiling against a MySQL C API prior to 5.7, the compilation
fails due to the reference to MYSQL_TYPE_JSON.

This patch will conditionally compile support for MYSQL_TYPE_JSON
only if it is supported in the underlying C API.

Resolves: Bug #80539