### PR TITLE
Added api.h to make it easier to include all headers

### DIFF
--- a/cppconn/api.h
+++ b/cppconn/api.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License, version 2.0, as
+ * published by the Free Software Foundation.
+ *
+ * This program is also distributed with certain software (including
+ * but not limited to OpenSSL) that is licensed under separate terms,
+ * as designated in a particular file or component or in included license
+ * documentation.  The authors of MySQL hereby grant you an
+ * additional permission to link the program and your derivative works
+ * with the separately licensed software that they have included with
+ * MySQL.
+ *
+ * Without limiting anything contained in the foregoing, this file,
+ * which is part of MySQL Connector/C++, is also subject to the
+ * Universal FOSS Exception, version 1.0, a copy of which can be found at
+ * http://oss.oracle.com/licenses/universal-foss-exception.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License, version 2.0, for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
+ */
+
+#ifndef _SQL_JDBC_API_H_
+#define _SQL_JDBC_API_H_
+
+    #include "build_config.h"
+    #include "connection.h"
+    #include "datatype.h"
+    #include "driver.h"
+    #include "exception.h"
+    #include "metadata.h"
+    #include "parameter_metadata.h"
+    #include "prepared_statement.h"
+    #include "resultset_metadata.h"
+    #include "resultset.h"
+    #include "sqlstring.h"
+    #include "statement.h"
+    #include "variant.h"
+    #include "warning.h"
+
+#endif


### PR DESCRIPTION
Notably, in the documentation as seen here: https://dev.mysql.com/doc/dev/connector-cpp/8.0/usage.html

It asks you to connect to jdbc drivers using a `*` wildcard. Natively in C++ 11, 14, etc. these compilers do not support such syntax. I think for ease of use, it may be better to just have this `api.h` file available in order to include all required C files respectively.