### PR TITLE
Remove the cmake message for printing the config for protobuf

### DIFF
--- a/cdk/cmake/protobuf.cmake
+++ b/cdk/cmake/protobuf.cmake
@@ -210,7 +210,6 @@ else()
   add_custom_command(OUTPUT ${PROTOBUF_BUILD_STAMP}
     COMMAND ${CMAKE_COMMAND} --build . --config ${CONFIG_EXPR}
     WORKING_DIRECTORY ${WITH_PROTOBUF}
-    COMMENT "Building protobuf using configuration: $(Configuration)"
   )
 endif()
 


### PR DESCRIPTION
Looks like $<CONFIGURATION> was used with old cmake versions but
now it uses a generator expression ${CONFIG_EXPR}, which is not
expanded at the time this message is printed.