### PR TITLE
Bugfix: mysql-connector-cpp cmake files not work well when as a third party

### DIFF
--- a/cmake/libutils.cmake
+++ b/cmake/libutils.cmake
@@ -112,7 +112,7 @@ configure_file(
 if(NOT MSBUILD AND NOT TARGET save_linker_opts)
   add_executable(save_linker_opts ${LIBUTILS_SCRIPT_DIR}/save_linker_opts.cc)
   set_property(TARGET save_linker_opts PROPERTY
-    OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}
+    OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   )
 endif()
 
@@ -217,7 +217,7 @@ function(merge_libraries TARGET)
 
     add_dependencies(${TARGET}-deps save_linker_opts)
     set_target_properties(${TARGET}-deps PROPERTIES
-      RULE_LAUNCH_LINK "${CMAKE_BINARY_DIR}/save_linker_opts ${log_file}.STATIC "
+      RULE_LAUNCH_LINK "${CMAKE_CURRENT_BINARY_DIR}/save_linker_opts ${log_file}.STATIC "
     )
 
     # Arrange for ${TARGET}-deps to be built before ${TARGET}
@@ -235,7 +235,7 @@ function(merge_libraries TARGET)
     #
 
     set_target_properties(${TARGET} PROPERTIES
-      RULE_LAUNCH_LINK "${CMAKE_BINARY_DIR}/save_linker_opts ${log_file}.SHARED "
+      RULE_LAUNCH_LINK "${CMAKE_CURRENT_BINARY_DIR}/save_linker_opts ${log_file}.SHARED "
     )
 
   else(NOT MSBUILD)

--- a/config.cmake
+++ b/config.cmake
@@ -56,6 +56,6 @@ else()
   SET(CONCPP_LICENSE "GPL-2.0")
 endif()
 
-CONFIGURE_FILE(config.h.in   ${CMAKE_BINARY_DIR}/include/config.h)
+CONFIGURE_FILE(config.h.in   ${CMAKE_CURRENT_BINARY_DIR}/include/config.h)
 INCLUDE_DIRECTORIES(${CMAKE_CURRENT_BINARY_DIR}/include)
 


### PR DESCRIPTION
When using mysql-connector-cpp as a third-party code in project like below:

```cmake
project(XDEV-DEMO)

cmake_minimum_required(VERSION 3.0.2)

add_subdirectory(third_party/mysql-connector-cpp)
include_directories(third_party/mysql-connector-cpp/include)

add_executable(demo demo.cc)
target_link_libraries(demo connector)
```

mysql-connector-cpp will not compile correctly when as a submodule project.