### PR TITLE
Bugfix: Macro INTERNAL conflict with gRPC header status contant defin…

### DIFF
--- a/include/mysqlx/common/api.h
+++ b/include/mysqlx/common/api.h
@@ -165,16 +165,16 @@ MYSQLX_ABI_END(2,0)
 
 #if defined CONCPP_BUILD_SHARED
   #define PUBLIC_API  DLL_EXPORT
-  #define INTERNAL    DLL_LOCAL
+  #define INTERNAL_API   DLL_LOCAL
 #elif defined CONCPP_BUILD_STATIC
   #define PUBLIC_API
-  #define INTERNAL
+  #define INTERNAL_API
 #elif !defined STATIC_CONCPP
   #define PUBLIC_API  DLL_IMPORT
-  #define INTERNAL
+  #define INTERNAL_API
 #else
   #define PUBLIC_API
-  #define INTERNAL
+  #define INTERNAL_API
 #endif
 
 

--- a/include/mysqlx/devapi/detail/result.h
+++ b/include/mysqlx/devapi/detail/result.h
@@ -238,7 +238,7 @@ public:
   friend Result_detail;
   friend RowResult;
 
-  struct INTERNAL Access;
+  struct INTERNAL_API Access;
   friend Access;
 };
 

--- a/include/mysqlx/devapi/detail/row.h
+++ b/include/mysqlx/devapi/detail/row.h
@@ -58,7 +58,7 @@ class PUBLIC_API Row_detail
 {
 protected:
 
-  class INTERNAL Impl;
+  class INTERNAL_API Impl;
   DLL_WARNINGS_PUSH
   std::shared_ptr<Impl>  m_impl;
   DLL_WARNINGS_POP

--- a/include/mysqlx/devapi/detail/session.h
+++ b/include/mysqlx/devapi/detail/session.h
@@ -291,7 +291,7 @@ protected:
   common::Shared_session_pool& get_session_pool();
 
 
-  struct INTERNAL Impl;
+  struct INTERNAL_API Impl;
 
   DLL_WARNINGS_PUSH
   Shared_client_impl  m_impl = NULL;
@@ -351,7 +351,7 @@ protected:
   }
 
 
-  struct INTERNAL Impl;
+  struct INTERNAL_API Impl;
 
   /*
     Note: Session implementation is shared with result objects because it
@@ -394,7 +394,7 @@ protected:
     return *m_impl;
   }
 
-  INTERNAL cdk::Session& get_cdk_session();
+  INTERNAL_API cdk::Session& get_cdk_session();
 
   void close();
 

--- a/include/mysqlx/devapi/document.h
+++ b/include/mysqlx/devapi/document.h
@@ -78,7 +78,7 @@ class PUBLIC_API DbDoc
 {
   // TODO: move PUBLIC_API stuff to a detail class
 
-  class INTERNAL Impl;
+  class INTERNAL_API Impl;
 
 DLL_WARNINGS_PUSH
 
@@ -86,7 +86,7 @@ DLL_WARNINGS_PUSH
 
 DLL_WARNINGS_POP
 
-  INTERNAL DbDoc(const std::shared_ptr<Impl>&);
+  INTERNAL_API DbDoc(const std::shared_ptr<Impl>&);
 
   const char* get_json() const;
 
@@ -517,7 +517,7 @@ public:
   friend mysqlx::string;
   ///@endcond IGNORE
 
-  struct INTERNAL Access;
+  struct INTERNAL_API Access;
   friend Access;
 };
 

--- a/include/mysqlx/devapi/result.h
+++ b/include/mysqlx/devapi/result.h
@@ -431,7 +431,7 @@ protected:
 public:
 
   friend RowResult;
-  struct INTERNAL Access;
+  struct INTERNAL_API Access;
   friend Access;
 };
 


### PR DESCRIPTION
The Macro INTERNAL will result in conflict with google gRPC status code defintion.
reference: https://github.com/grpc/grpc/blob/master/include/grpcpp/impl/codegen/status_code_enum.h

In grpc/include/grpcpp/impl/codegen/status_code_enum.h , enum StatusCode
117-  /// Internal errors. Means some invariants expected by underlying System has
118-  /// been broken. If you see one of these errors, Something is very broken.
119:  INTERNAL = 13,

Replace Macro INTERNAL with INTERNAL_API will solve this conflict.