### PR TITLE
Fix broken get_target_property in DepFindProtobuf.cmake

### DIFF
--- a/cdk/cmake/DepFindProtobuf.cmake
+++ b/cdk/cmake/DepFindProtobuf.cmake
@@ -186,7 +186,7 @@ foreach(tgt protobuf protobuf-lite protoc)
 
     #message("- CONF: ${CONF}")
 
-    get_target_property(LOC pb_${tgt} IMPORTED_LOCATION_${CONF})
+    get_target_property(LOC ${TGT_${tgt}} IMPORTED_LOCATION_${CONF})
 
     if(LOC)
 


### PR DESCRIPTION
`pb_${tgt}` cannot be found. Assumed mistake, as all other calls to `get_target_property` use `${TGT_${tgt}}`, changed accordingly.