### PR TITLE
Define copy/move functions to make Db_obj_base and its derived classes nothrow movable

### DIFF
--- a/include/mysqlx/devapi/detail/session.h
+++ b/include/mysqlx/devapi/detail/session.h
@@ -85,6 +85,11 @@ protected:
     : m_sess(sess), m_name(name)
   {}
 
+  Db_obj_base(const Db_obj_base&) = default;
+  Db_obj_base& operator=(const Db_obj_base&) = default;
+  Db_obj_base(Db_obj_base&&) = default;
+  Db_obj_base& operator=(Db_obj_base&&) = default;
+
   virtual ~Db_obj_base()
   {}
 };


### PR DESCRIPTION
class `mysqlx::internal::Db_obj_base` has only destructor defined => its move constructor/assignment is implicitly deleted. Therefore, if its derived classes (mysql::Schema) is used in container like std::vector, the container can not invoke move constructor when resizing.
Fixed by defining defaulted copy/move functions (Rule of 5).