### PR TITLE
WIN_STATIC_MSVCRT: fixed LIB_NAME_STATIC for WIN32 AND STATIC_MSVCRT

### DIFF
--- a/install_layout.cmake
+++ b/install_layout.cmake
@@ -177,7 +177,7 @@ set(LIB_NAME_BASE "mysqlcppconn${CONCPP_VERSION_MAJOR}")
 set(LIB_NAME_STATIC "${LIB_NAME_BASE}-static")
 
 if(WIN32 AND STATIC_MSVCRT)
-  set(LIB_NAME_STATIC "${LIB_NAME}-mt")
+  set(LIB_NAME_STATIC "${LIB_NAME_BASE}-mt")
 endif()
 
 if(BUILD_STATIC)


### PR DESCRIPTION
Fix of this problem: wrong output lib name ("-mt.lib") on Windows when build cpp connector with -DSTATIC_MSVCRT=ON.