### PR TITLE
Fix windows compilation issue in cmake/libutils/save_linker_opts.cc

### DIFF
--- a/cmake/libutils/save_linker_opts.cc
+++ b/cmake/libutils/save_linker_opts.cc
@@ -30,7 +30,14 @@
 
 #include <iostream>
 #include <fstream>
+
+#ifdef WIN32
+#include <direct.h>
+#define GETCWD _getcwd
+#else
 #include <unistd.h>
+#define GETCWD getcwd
+#endif
 
 using namespace std;
 
@@ -38,7 +45,7 @@ int main(int argc, char* argv[])
 {
   char pwd[1024];
 
-  if (!getcwd(pwd, sizeof(pwd)))
+  if (!GETCWD(pwd, sizeof(pwd)))
     return 1;
 
   //cout << "Got " << argc << " arguments" << endl;


### PR DESCRIPTION
Fixed a compilation issue in Windows where "unistd.h" was still being used to call "getcwd".
Protected the "unistd.h" with a #ifdef WIN32 macro and added a windows alternative using the #include <direct.h> and the _getcwd counterpart for that OS.

I was getting this issue while compiling with Ninja, and after those changes everything now compiles as it should (against openssl 1.1.1q using VS 2019 (latest update) on a Windows 11 intel machine!)