### PR TITLE
Moving a local object in a return statement prevents copy elision.

### DIFF
--- a/include/mysqlx/common/util.h
+++ b/include/mysqlx/common/util.h
@@ -337,7 +337,7 @@ std::string to_upper(const std::string &val)
   std::string uc_val;
   uc_val.resize(val.size());
   transform(val.begin(), val.end(), uc_val.begin(), ::toupper);
-  return std::move(uc_val);
+  return uc_val;
 }
 
 inline
@@ -348,7 +348,7 @@ std::string to_lower(const std::string &val)
   std::string uc_val;
   uc_val.resize(val.size());
   transform(val.begin(), val.end(), uc_val.begin(), ::tolower);
-  return std::move(uc_val);
+  return uc_val;
 }
 
 }  // common


### PR DESCRIPTION
Hi, I hope you are well!

In this particular case, we integrate its library, but at the same time we have a general and global rule of not allowing warnings in compilation, and this warning (which is valid) does not allow this.


https://gcc.gnu.org/onlinedocs/gcc/C_002b_002b-Dialect-Options.html

![image](https://user-images.githubusercontent.com/14300208/191664640-87520dbb-ae26-424b-bd44-a543a49c4ccf.png)

![image](https://user-images.githubusercontent.com/14300208/191664080-d5ab6053-2d86-4cca-b8f0-8806c3ffcd8c.png)


I already sign the Oracle Contribution Agreement.
