### PR TITLE
cmake: Fix the problem that the merged static library path is not an absolute path

### DIFF
--- a/cmake/libutils/merge_archives.cmake.in
+++ b/cmake/libutils/merge_archives.cmake.in
@@ -571,9 +571,9 @@ function(process_deps)
       AND EXISTS "${libpath}"
     )
       if(lib MATCHES "protobuf|uuid_gen|libssl|libcrypto|mysqlclient")
-        list(APPEND LIBS1 "${lib}")
+        list(APPEND LIBS1 "${libpath}")
       else()
-        list(APPEND LIBS "${lib}")
+        list(APPEND LIBS "${libpath}")
       endif()
     endif()
 


### PR DESCRIPTION
When building static libraries, the cmake/libutils/merge_archives.cmake.in used for merging does not utilize absolute paths due to a logic error. This issue manifests as a warning about non-existent files being printed after executing the `ar` process, particularly when using Ninja to build within a subproject.