### PR TITLE
Fix bug where read/write timeout option checks were swapped

### DIFF
--- a/cdk/foundation/connection_tcpip.cc
+++ b/cdk/foundation/connection_tcpip.cc
@@ -78,9 +78,9 @@ void connection_TCPIP_impl::do_connect()
 
   // Note: Setting timeouts in microseconds. No need to convert.
 
-  if (m_opts.has_write_timeout())
-    connection::detail::set_timeout(m_sock, m_opts.get_read_timeout(), true);
   if (m_opts.has_read_timeout())
+    connection::detail::set_timeout(m_sock, m_opts.get_read_timeout(), true);
+  if (m_opts.has_write_timeout())
     connection::detail::set_timeout(m_sock, m_opts.get_write_timeout(), false);
 }
 
@@ -129,9 +129,9 @@ void connection_Unix_socket_impl::do_connect()
   // Note: Conversion from milliseconds to microseconds.
   // TODO: Do we really need/want to set timeouts on Unix socket?
 
-  if (m_opts.has_write_timeout())
-    connection::detail::set_timeout(m_sock, 1000 * m_opts.get_read_timeout(), true);
   if (m_opts.has_read_timeout())
+    connection::detail::set_timeout(m_sock, 1000 * m_opts.get_read_timeout(), true);
+  if (m_opts.has_write_timeout())
     connection::detail::set_timeout(m_sock, 1000 * m_opts.get_write_timeout(), false);
 }
 


### PR DESCRIPTION
The presence of a read timeout was being checked before setting a write timeout on the socket, and vice versa. This commit swaps them back.